### PR TITLE
Replace slashes on Darwin

### DIFF
--- a/keep-to-markdown.py
+++ b/keep-to-markdown.py
@@ -24,6 +24,7 @@ def clean_title(title) -> str:
         title = title.replace('/', '_')
     elif ostype == 'Darwin':
         title = title.replace(':', ' ')
+        title = title.replace('\\', '_').replace('/', '_').replace('|', '_')
     elif ostype == 'Windows':
         title = title.replace('\\', '_').replace('/', '_').replace('|', '_')
         title = title.replace('<', '-').replace('>', '-').replace(':', ' ')


### PR DESCRIPTION
Thanks for this script! I had some notes with slashes in the title that were crashing the script on macOS 11.4 (and presumably all Darwin systems)