### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ optional arguments:
   -h, --help    Show this help message and exit
   -t            Use subfolders for tags instead of YAML front-matter
   -x            Generate hashtags instead of semicolon-separated tags
-  -a            Use the first annotation, if no tittle is aviable
+  -a            Use the first annotation, if no title is available
 ```
 
 The script outputs to a `notes` directory. Images will be stored in `notes/resources`.


### PR DESCRIPTION
Replaced "tittle" with "title" and "aviable" with "available" in line 22.